### PR TITLE
Switch to using png_jmpbuf to support older libpng versions.

### DIFF
--- a/ffi.rs
+++ b/ffi.rs
@@ -27,23 +27,18 @@ pub static COLOR_TYPE_RGBA: c_int = 6;
 pub type png_struct = c_void;
 pub type png_info = c_void;
 
-pub extern fn rust_longjmp(env: *c_void, val: c_int) {
-    unsafe { longjmp(env, val); }
-}
-
 pub extern {
     // libc routines needed
     pub fn setjmp(env: *c_void) -> c_int;
-    pub fn longjmp(env: *c_void, val: c_int);
 
     // shim routines
-    pub fn jmp_buf_size() -> size_t;
+    pub fn pngshim_jmpbuf(pnt_ptr: *mut png_struct) -> *c_void;
 
+    // libpng routines
     pub fn png_get_header_ver(png_ptr: *png_struct) -> *c_char;
     pub fn png_sig_cmp(sig: *u8, start: size_t, num_to_check: size_t) -> c_int;
 
     pub fn png_create_info_struct(png_ptr: *png_struct) -> *mut png_info;
-    pub fn png_set_longjmp_fn(png_ptr: *mut png_struct, longjmp_fn: *u8, jmp_buf_size: size_t) -> *c_void;
     pub fn png_get_io_ptr(png_ptr: *png_struct) -> *mut c_void;
     pub fn png_set_sig_bytes(png_ptr: *mut png_struct, num_bytes: c_int);
 

--- a/lib.rs
+++ b/lib.rs
@@ -70,7 +70,7 @@ pub fn load_png(path: &Path) -> Result<Image,~str> {
             ffi::png_destroy_read_struct(&png_ptr, ptr::null(), ptr::null());
             return Err(~"could not create info struct");
         }
-        let res = ffi::setjmp(ffi::png_set_longjmp_fn(png_ptr, ffi::rust_longjmp, ffi::jmp_buf_size()));
+        let res = ffi::setjmp(ffi::pngshim_jmpbuf(png_ptr));
         if res != 0 {
             let png_ptr: *ffi::png_struct = &*png_ptr;
             let info_ptr: *ffi::png_info = &*info_ptr;
@@ -155,7 +155,7 @@ pub fn store_png(img: &Image, path: &Path) -> Result<(),~str> {
             ffi::png_destroy_write_struct(&png_ptr, ptr::null());
             return Err(~"could not create info struct");
         }
-        let res = ffi::setjmp(ffi::png_set_longjmp_fn(png_ptr, ffi::rust_longjmp, ffi::jmp_buf_size()));
+        let res = ffi::setjmp(ffi::pngshim_jmpbuf(png_ptr));
         if res != 0 {
             let png_ptr: *ffi::png_struct = &*png_ptr;
             let info_ptr: *ffi::png_info = &*info_ptr;

--- a/shim.c
+++ b/shim.c
@@ -1,6 +1,6 @@
-#include <stddef.h>
 #include <setjmp.h>
+#include <png.h>
 
-size_t jmp_buf_size() {
-  return sizeof(jmp_buf);
+jmp_buf *pngshim_jmpbuf(png_struct *png_ptr) {
+  return &png_jmpbuf(png_ptr);
 }


### PR DESCRIPTION
Recent libpng has png_jmpbuf `#define`d to a call to `png_set_longjmp_fn`, but
this function did not exist in 1.2.x. This has a side effect of cleaning up
the shim code a bit.

We need libpng 1.2 support because Centos6 (used by Moz RelEng) only has 1.2.
