### PR TITLE
support android build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,9 @@ CFLAGS += -fPIC
 AR ?= ar
 RUSTC ?= rustc
 RUSTFLAGS ?=
+ifeq ($(CFG_OSTYPE),linux-androideabi)
+RUSTFLAGS += -L ../../../platform/android/libpng/.libs
+endif
 
 .PHONY: all
 all:	librustpng.dummy


### PR DESCRIPTION
Same case of libfreetype and libfontconfig. (src/.libs)
If those libraries would be change, we also fix this, too. 
