### PR TITLE
Fix the build issue related to Macports-installed libpng on Mac

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,10 +2,11 @@ VPATH=%VPATH%
 
 CC ?= gcc
 CXX ?= g++
-CFLAGS += -fPIC -I../png
+CFLAGS += -fPIC -I$(VPATH)/../png
 AR ?= ar
 RUSTC ?= rustc
 RUSTFLAGS ?=
+RUSTFLAGS += ../png
 ifeq ($(CFG_OSTYPE),linux-androideabi)
 RUSTFLAGS += -L ../../../platform/android/libpng/.libs
 endif


### PR DESCRIPTION
Pull libpng to the code tree.
