### PR TITLE
Build with --opt-level=3.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,7 @@ CFLAGS += -fPIC -I$(VPATH)/../libpng
 AR ?= ar
 RUSTC ?= rustc
 RUSTFLAGS ?=
-RUSTFLAGS += -L ../libpng
+RUSTFLAGS += -L ../libpng --opt-level=3
 
 .PHONY: all
 all:	librustpng.dummy


### PR DESCRIPTION
This speeds up PNG decoding by about 6x.
