### PR TITLE
Truncate output files created in store_png

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -187,7 +187,7 @@ pub extern fn flush_data(png_ptr: *ffi::png_struct) {
 
 #[fixed_stack_segment]
 pub fn store_png(img: &Image, path: &Path) -> Result<(),~str> {
-    let mut file = match File::open_mode(path, io::Open, io::Write) {
+    let mut file = match File::open_mode(path, io::Truncate, io::Write) {
         Some(file) => file,
         None => return Err(~"could not open file")
     };


### PR DESCRIPTION
Use io::Truncate instead of io::Open for file mode.

I also have a `backport_truncate_write` branch in my repo that is compatible with the version of rust used by servo.

Related to https://github.com/mozilla/servo/issues/1178.