### PR TITLE
Upgrade Rust

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -24,7 +24,7 @@ use std::slice;
 
 pub mod ffi;
 
-#[deriving(Eq,Show)]
+#[deriving(PartialEq,Eq,Show)]
 pub enum ColorType {
     K1, K2, K4, K8, K16,
     KA8, KA16,


### PR DESCRIPTION
Eq now needs PartialEq trait. https://github.com/mozilla/rust/pull/14492
This might only need PartialEq instead of Both Eq and PartialEq.
