### PR TITLE
Update to the last rust-nightly.

### DIFF
--- a/ffi.rs
+++ b/ffi.rs
@@ -38,43 +38,43 @@ pub type png_info = c_void;
 #[link(name = "shim")]
 extern {
     // libc routines needed
-    pub fn setjmp(env: *c_void) -> c_int;
+    pub fn setjmp(env: *const c_void) -> c_int;
 
     // shim routines
-    pub fn pngshim_jmpbuf(pnt_ptr: *mut png_struct) -> *c_void;
+    pub fn pngshim_jmpbuf(pnt_ptr: *mut png_struct) -> *const c_void;
 
     // libpng routines
-    pub fn png_get_header_ver(png_ptr: *png_struct) -> *c_char;
-    pub fn png_sig_cmp(sig: *u8, start: size_t, num_to_check: size_t) -> c_int;
+    pub fn png_get_header_ver(png_ptr: *const png_struct) -> *const c_char;
+    pub fn png_sig_cmp(sig: *const u8, start: size_t, num_to_check: size_t) -> c_int;
 
-    pub fn png_create_info_struct(png_ptr: *png_struct) -> *mut png_info;
-    pub fn png_get_io_ptr(png_ptr: *png_struct) -> *mut c_void;
+    pub fn png_create_info_struct(png_ptr: *const png_struct) -> *mut png_info;
+    pub fn png_get_io_ptr(png_ptr: *const png_struct) -> *mut c_void;
     pub fn png_set_sig_bytes(png_ptr: *mut png_struct, num_bytes: c_int);
 
-    pub fn png_create_read_struct(user_png_ver: *c_char, error_ptr: *c_void, error_fn: *u8, warn_fn: *u8) -> *mut png_struct;
-    pub fn png_destroy_read_struct(png_ptr_ptr: **png_struct, info_ptr_ptr: **png_info, end_info_ptr_ptr: **png_info);
-    pub fn png_set_read_fn(png_ptr: *mut png_struct, io_ptr: *mut c_void, read_data_fn: extern "C" fn(*png_struct, *mut u8, size_t));
+    pub fn png_create_read_struct(user_png_ver: *const c_char, error_ptr: *const c_void, error_fn: *const u8, warn_fn: *const u8) -> *mut png_struct;
+    pub fn png_destroy_read_struct(png_ptr_ptr: *const *const png_struct, info_ptr_ptr: *const *const png_info, end_info_ptr_ptr: *const *const png_info);
+    pub fn png_set_read_fn(png_ptr: *mut png_struct, io_ptr: *mut c_void, read_data_fn: extern "C" fn(*const png_struct, *mut u8, size_t));
     pub fn png_read_info(png_ptr: *mut png_struct, info_ptr: *mut png_info);
     pub fn png_read_update_info(png_ptr: *mut png_struct, info_ptr: *mut png_info);
-    pub fn png_read_image(png_ptr: *mut png_struct, row_pointers: **mut u8);
-    pub fn png_read_png(png_ptr: *mut png_struct, info_ptr: *mut png_info, transforms: c_int, params: *c_void);
+    pub fn png_read_image(png_ptr: *mut png_struct, row_pointers: *const *mut u8);
+    pub fn png_read_png(png_ptr: *mut png_struct, info_ptr: *mut png_info, transforms: c_int, params: *const c_void);
 
-    pub fn png_create_write_struct(user_png_ver: *c_char, error_ptr: *c_void, error_fn: *u8, warn_fn: *u8) -> *mut png_struct;
-    pub fn png_destroy_write_struct(png_ptr_ptr: **png_struct, info_ptr_ptr: **png_info);
-    pub fn png_set_write_fn(png_ptr: *mut png_struct, io_ptr: *mut c_void, write_data_fn: extern "C" fn(*png_struct, *u8, size_t), output_flush_ptr: extern "C" fn(*png_struct));
-    pub fn png_write_png(pnt_ptr: *mut png_struct, info_ptr: *mut png_info, transforms: c_int, params: *c_void); // ??
+    pub fn png_create_write_struct(user_png_ver: *const c_char, error_ptr: *const c_void, error_fn: *const u8, warn_fn: *const u8) -> *mut png_struct;
+    pub fn png_destroy_write_struct(png_ptr_ptr: *const *const png_struct, info_ptr_ptr: *const *const png_info);
+    pub fn png_set_write_fn(png_ptr: *mut png_struct, io_ptr: *mut c_void, write_data_fn: extern "C" fn(*const png_struct, *const u8, size_t), output_flush_ptr: extern "C" fn(*const png_struct));
+    pub fn png_write_png(pnt_ptr: *mut png_struct, info_ptr: *mut png_info, transforms: c_int, params: *const c_void); // ??
 
-    pub fn png_get_IHDR(png_ptr: *png_struct, info_ptr: *png_info, width: *mut u32, height: *mut u32, bit_depth: *mut c_int, color_type: *mut c_int, interlace_method: *mut c_int, compression_method: *mut c_int, filter_method: *mut c_int) -> u32;
-    pub fn png_get_pHYs(png_ptr: *png_struct, info_ptr: *png_info, res_x: *mut u32, res_y: *mut u32, unit_type: *mut c_int) -> u32;
-    pub fn png_get_image_width(png_ptr: *png_struct, info_ptr: *png_info) -> u32;
-    pub fn png_get_image_height(png_ptr: *png_struct, info_ptr: *png_info) -> u32;
-    pub fn png_get_bit_depth(png_ptr: *png_struct, info_ptr: *png_info) -> u8;
-    pub fn png_get_color_type(png_ptr: *png_struct, info_ptr: *png_info) -> u8;
-    pub fn png_get_rows(png_ptr: *png_struct, info_ptr: *png_info) -> **u8;
+    pub fn png_get_IHDR(png_ptr: *const png_struct, info_ptr: *const png_info, width: *mut u32, height: *mut u32, bit_depth: *mut c_int, color_type: *mut c_int, interlace_method: *mut c_int, compression_method: *mut c_int, filter_method: *mut c_int) -> u32;
+    pub fn png_get_pHYs(png_ptr: *const png_struct, info_ptr: *const png_info, res_x: *mut u32, res_y: *mut u32, unit_type: *mut c_int) -> u32;
+    pub fn png_get_image_width(png_ptr: *const png_struct, info_ptr: *const png_info) -> u32;
+    pub fn png_get_image_height(png_ptr: *const png_struct, info_ptr: *const png_info) -> u32;
+    pub fn png_get_bit_depth(png_ptr: *const png_struct, info_ptr: *const png_info) -> u8;
+    pub fn png_get_color_type(png_ptr: *const png_struct, info_ptr: *const png_info) -> u8;
+    pub fn png_get_rows(png_ptr: *const png_struct, info_ptr: *const png_info) -> *const *const u8;
 
-    pub fn png_set_IHDR(png_ptr: *png_struct, info_ptr: *mut png_info, width: u32, height: u32, bit_depth: c_int, color_type: c_int, interlace_method: c_int, compression_method: c_int, filter_method: c_int);
-    pub fn png_set_pHYs(png_ptr: *png_struct, info_ptr: *mut png_info, res_x: u32, res_y: u32, unit_type: c_int);
-    pub fn png_set_rows(png_ptr: *png_struct, info_ptr: *mut png_info, row_pointers: **u8);
+    pub fn png_set_IHDR(png_ptr: *const png_struct, info_ptr: *mut png_info, width: u32, height: u32, bit_depth: c_int, color_type: c_int, interlace_method: c_int, compression_method: c_int, filter_method: c_int);
+    pub fn png_set_pHYs(png_ptr: *const png_struct, info_ptr: *mut png_info, res_x: u32, res_y: u32, unit_type: c_int);
+    pub fn png_set_rows(png_ptr: *const png_struct, info_ptr: *mut png_info, row_pointers: *const *const u8);
 
     pub fn png_set_packing(png_ptr: *mut png_struct);
     pub fn png_set_palette_to_rgb(png_ptr: *mut png_struct);


### PR DESCRIPTION
Version on rustc: 0.11.0-nightly (459f155f81291c46633e86a480628b50304ffb1c 2014-07-04 23:46:44 +0000).

Non-mutable pointers become `*const`.
