### PR TITLE
Extract write_png function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /doc
 /target
 /Cargo.lock
+
+test/store.png

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,8 +244,8 @@ mod test {
     use std::io;
     use std::io::File;
 
-    use super::{ffi, load_png, load_png_from_memory, store_png};
-    use super::{RGB8, RGBA8, K8, KA8, Image};
+    use super::{ffi, load_png, load_png_from_memory, store_png, Image};
+    use super::PixelsByColorType::{RGB8, RGBA8, K8, KA8};
 
     #[test]
     fn test_valid_png() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,10 +188,13 @@ pub fn store_png(img: &mut Image, path: &Path) -> Result<(),String> {
         Err(e) => return Err(format!("{}", e))
     };
 
-    let mut writer = &mut file as &mut io::Writer;
+    let mut writer = &mut file;
+    write_png(img, writer)
+}
 
+pub fn write_png(img: &mut Image, writer: &mut io::Writer) -> Result<(), String> {
     // Box it again because a &Trait is too big to fit in a void*.
-    let writer = &mut writer;
+    let writer = &writer;
 
     unsafe {
         let mut png_ptr = ffi::png_create_write_struct(&*ffi::png_get_header_ver(ptr::null_mut()),


### PR DESCRIPTION
A small refactoring that moves most of `store_png` into a new `write_png` function. This allows any `Writer`, like stdout, to receive the png bytes. Now `store_png` is responsible only for creating the file and delegates the png serialization to `write_png`.