### PR TITLE
Handle 16-bit chennels by stripping them to 8-bit.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -84,4 +84,5 @@ extern {
     pub fn RUST_png_set_add_alpha(png_ptr: *mut png_struct, val: u32, flag: c_int);
     pub fn RUST_png_set_filler(png_ptr: *mut png_struct, val: u32, flag: c_int);
     pub fn RUST_png_set_interlace_handling(png_ptr: *mut png_struct);
+    pub fn RUST_png_set_strip_16(png_ptr: *mut png_struct);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub fn load_png_from_memory(image: &[u8]) -> Result<Image,String> {
         let width = ffi::RUST_png_get_image_width(png_ptr, info_ptr);
         let height = ffi::RUST_png_get_image_height(png_ptr, info_ptr);
         let color_type = ffi::RUST_png_get_color_type(png_ptr, info_ptr);
+        let bit_depth = ffi::RUST_png_get_bit_depth(png_ptr, info_ptr);
 
         // convert palette and grayscale to rgb
         match color_type as c_int {
@@ -116,6 +117,11 @@ pub fn load_png_from_memory(image: &[u8]) -> Result<Image,String> {
                 ffi::RUST_png_set_gray_to_rgb(png_ptr);
             }
             _ => {}
+        }
+
+        // convert 16-bit channels to 8-bit
+        if bit_depth == 16 {
+            ffi::RUST_png_set_strip_16(png_ptr);
         }
 
         // add alpha channels


### PR DESCRIPTION
This page: http://betterexplained.com/articles/linear-algebra-guide/ was causing Servo crash because of 16-bit grayscale images. Patch fixes this.