### PR TITLE
Updated to build with 1.0.0-beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ build = "build.rs"
 [dependencies.png-sys]
 path = "png-sys"
 
+[dependencies]
+libc = "0.1.5"
+
 [build-dependencies.gcc]
 git = "https://github.com/alexcrichton/gcc-rs"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,6 @@
-#![feature(os, path)]
-
 extern crate gcc;
 
-use std::default::Default;
-use std::os;
+use std::env;
 use std::path::PathBuf;
 
 fn main() {
@@ -11,10 +8,10 @@ fn main() {
 
     cfg.file("src/shim.c");
 
-    let src_dir = PathBuf::new(&os::getenv("CARGO_MANIFEST_DIR").unwrap()).join("png-sys/libpng-1.6.16");
+    let src_dir = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("png-sys/libpng-1.6.16");
     cfg.include(&src_dir);
 
-    let dep_dir = PathBuf::new(&os::getenv("DEP_PNG_ROOT").unwrap());
+    let dep_dir = PathBuf::from(&env::var("DEP_PNG_ROOT").unwrap());
     cfg.include(&dep_dir);
 
     cfg.compile("libpngshim.a")

--- a/png-sys/Cargo.toml
+++ b/png-sys/Cargo.toml
@@ -8,5 +8,5 @@ links = "png"
 build = "build.rs"
 
 [lib]
-name = "png-sys"
+name = "png_sys"
 path = "lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,15 +246,14 @@ pub fn store_png<P: AsRef<Path>>(img: &mut Image, path: P) -> Result<(),String> 
 
 #[cfg(test)]
 mod test {
-    extern crate test;
     use std::error::Error;
     use std::fs::File;
     use std::io::Read;
     use std::iter::repeat;
     use std::path::PathBuf;
 
-    use super::{ffi, load_png, load_png_from_memory, store_png, Image};
-    use super::PixelsByColorType::{RGB8, RGBA8, K8, KA8};
+    use super::{ffi, load_png, store_png, Image};
+    use super::PixelsByColorType::{RGB8, RGBA8};
 
     #[test]
     fn test_valid_png() {
@@ -300,49 +299,51 @@ mod test {
         load_rgba8("test/gray.png", 100, 100);
     }
 
-    fn bench_file_from_memory(b: &mut test::Bencher, file: &'static str,
-                              w: u32, h: u32, c: &'static str) {
-        let mut reader = match File::open(file) {
-            Ok(r) => r,
-            Err(e) => panic!("could not open '{}': {}", file, e.description())
-        };
-        let mut buf = vec![];
-        match reader.read_to_end(&mut buf) {
-            Ok(_) => (),
-            Err(e) => panic!(e)
-        }
-        b.bench_n(1, |b| b.iter(|| {
-            match load_png_from_memory(buf.as_slice()) {
-                Err(m) => panic!(m),
-                Ok(image) => {
-                    let color_type = match image.pixels {
-                        K8(_) => "K8",
-                        KA8(_) => "KA8",
-                        RGB8(_) => "RGB8",
-                        RGBA8(_) => "RGBA8",
-                    };
-                    assert_eq!(color_type, c);
-                    assert_eq!(image.width, w);
-                    assert_eq!(image.height, h);
-                }
-            }
-        }));
-    }
-
-    #[bench]
-    fn test_load_perf_screenshot(b: &mut test::Bencher) {
-        bench_file_from_memory(b, "test/servo-screenshot.png", 831, 624, "RGBA8");
-    }
-
-    #[bench]
-    fn test_load_perf_dino(b: &mut test::Bencher) {
-        bench_file_from_memory(b, "test/mozilla-dinosaur-head-logo.png", 1300, 929, "RGBA8");
-    }
-
-    #[bench]
-    fn test_load_perf_rust(b: &mut test::Bencher) {
-        bench_file_from_memory(b, "test/rust-huge-logo.png", 4000, 4000, "RGBA8");
-    }
+    // // test::Bencher is unstable in beta, so these are commented out for the time being.
+    //
+    // fn bench_file_from_memory(b: &mut test::Bencher, file: &'static str,
+    //                           w: u32, h: u32, c: &'static str) {
+    //     let mut reader = match File::open(file) {
+    //         Ok(r) => r,
+    //         Err(e) => panic!("could not open '{}': {}", file, e.description())
+    //     };
+    //     let mut buf = vec![];
+    //     match reader.read_to_end(&mut buf) {
+    //         Ok(_) => (),
+    //         Err(e) => panic!(e)
+    //     }
+    //     b.bench_n(1, |b| b.iter(|| {
+    //         match load_png_from_memory(buf.as_slice()) {
+    //             Err(m) => panic!(m),
+    //             Ok(image) => {
+    //                 let color_type = match image.pixels {
+    //                     K8(_) => "K8",
+    //                     KA8(_) => "KA8",
+    //                     RGB8(_) => "RGB8",
+    //                     RGBA8(_) => "RGBA8",
+    //                 };
+    //                 assert_eq!(color_type, c);
+    //                 assert_eq!(image.width, w);
+    //                 assert_eq!(image.height, h);
+    //             }
+    //         }
+    //     }));
+    // }
+    //
+    // #[bench]
+    // fn test_load_perf_screenshot(b: &mut test::Bencher) {
+    //     bench_file_from_memory(b, "test/servo-screenshot.png", 831, 624, "RGBA8");
+    // }
+    //
+    // #[bench]
+    // fn test_load_perf_dino(b: &mut test::Bencher) {
+    //     bench_file_from_memory(b, "test/mozilla-dinosaur-head-logo.png", 1300, 929, "RGBA8");
+    // }
+    //
+    // #[bench]
+    // fn test_load_perf_rust(b: &mut test::Bencher) {
+    //     bench_file_from_memory(b, "test/rust-huge-logo.png", 4000, 4000, "RGBA8");
+    // }
 
     #[test]
     fn test_store() {


### PR DESCRIPTION
The tests don't work, but that seems unavoidable since the `test`
feature is unstable (so `extern crate test` simply won't compile).