### PR TITLE
Specify RANLIB for android builds

### DIFF
--- a/png-sys/build.rs
+++ b/png-sys/build.rs
@@ -11,8 +11,10 @@ fn main() {
     if is_android {
         let cc = format!("{}-gcc", target);
         let ar = format!("{}-ar", target);
+        let ranlib = format!("{}-ranlib", target);
         env::set_var("CC", &cc);
         env::set_var("AR", &ar);
+        env::set_var("RANLIB", &ranlib);
     }
 
     let cfg = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("libpng-1.6.16/configure");


### PR DESCRIPTION
When cross compiling from OSX to Android the build system for libpng would
otherwise invoke the system `ranlib` on an android-targeting archive. This
invocation would then corrupt the archive, preventing the compiler from working
with it.

By setting `RANLIB` to the android-specific `ranlib` tool the build system won't
corrupt the archive, allowing rustc to read it and continue processing it.