### PR TITLE
Use vec! macro instead of iterator to initialise buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub fn load_png_from_memory(image: &[u8]) -> Result<Image, String> {
             _ => panic!("color type not supported"),
         };
 
-        let mut image_data: Vec<u8> = repeat(0u8).take(width * height * pixel_width).collect();
+        let mut image_data: Vec<u8> = vec![0u8;width * height * pixel_width];
         let image_buf = image_data.as_mut_ptr();
         let mut row_pointers: Vec<*mut u8> = (0..height).map(|idx| {
             image_buf.offset((width * pixel_width * idx) as isize)


### PR DESCRIPTION
The vec! macro is much faster than using `collect` to initialise a vector.
This change decreases the run time of `load_png_from_memory` by 20%-30%
on my machine.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-png/81)

<!-- Reviewable:end -->
